### PR TITLE
feat(react-components): show "View all results" button even if there …

### DIFF
--- a/packages/bundle/src/config.ts
+++ b/packages/bundle/src/config.ts
@@ -126,6 +126,7 @@ export default process.env.NODE_ENV !== 'development'
                    "suggestionsTitle": "Suggestions",
                    "productMatchesTitle": "Product matches",
                    "tipResults": "View all results for query",
+                   "tipTrendingResults": "View all results",
                    "tipTrending": "Sorry, we can't find any suggestions. Press enter to search for",
                    "viewMore": "View all",
                    "trendingSearches": "Trending searches",

--- a/packages/react-components/src/components/autocomplete/Tip/view.tsx
+++ b/packages/react-components/src/components/autocomplete/Tip/view.tsx
@@ -5,8 +5,6 @@
 import React, { useCallback } from 'react'
 import classnames from 'classnames'
 import { useQuery } from '@findify/react-connect';
-import styles from 'components/autocomplete/Tip/styles.css';
-import { List } from 'immutable'
 import { ThemedSFCProps, ClassnamedProps, WidgetAwareProps, SuggestionsConnectedProps } from 'types';
 import { emit } from 'helpers/emmiter';
 
@@ -14,31 +12,38 @@ import { emit } from 'helpers/emmiter';
 export interface ITipProps extends ThemedSFCProps, ClassnamedProps, WidgetAwareProps, SuggestionsConnectedProps {
   /** Custom title to display in a Tip */
   title: string;
+  zeroResultsTitle: string;
 }
 
 const TipView: React.SFC<ITipProps> = ({
   className,
   title,
+  zeroResultsTitle,
   theme,
   widgetKey
 }: ITipProps) => {
   const {query} = useQuery();
   const onClick = useCallback(() =>
-    emit('search', widgetKey, query.get('q')),
+    emit('search', widgetKey, !query.get('q') ? '' : query.get('q')),
     [query]
   );
   return (
-    <div
-      display-if={query.get('q')}
-      className={classnames(theme.tip, className)}
-      onClick={onClick}
-      >
-      {title}
-      {' '}
-      {
-        <span className={theme.highlight}>{query.get('q')}</span>
-      }
-    </div>
+    <>
+      <div
+        display-if={!!query.get('q')}
+        className={classnames(theme.tip, className)}
+        onClick={onClick}
+        >
+        {title}
+        {' '}
+        {
+          <span className={theme.highlight}>{query.get('q')}</span>
+        }
+      </div>
+      <div display-if={!query.get('q')} className={classnames(theme.tip, className)} onClick={onClick}>
+        { zeroResultsTitle }
+      </div>
+    </>
   )
 }
 

--- a/packages/react-components/src/layouts/Autocomplete/Dropdown/view.tsx
+++ b/packages/react-components/src/layouts/Autocomplete/Dropdown/view.tsx
@@ -99,6 +99,7 @@ const AutocompleteDropdownView: React.SFC<IAutocompleteDropdownProps> = ({
         <Tip
           className={theme.tip}
           title={config.getIn(['i18n', 'tipResults'])}
+          zeroResultsTitle={config.getIn(['i18n', 'tipTrendingResults'], 'View All Results')}
           widgetKey={config.get('widgetKey')} />
         <div className={theme.container}>
           <Suggestions


### PR DESCRIPTION
…is no autocomplete query

affects: @findify/bundle, @findify/react-components

The trending autocomplete doesn't have a Tip at all, since we are now looking for the typed query.
However, for trending autocomplete, we say: 'View All Results' and submit and empty search.

ISSUES CLOSED: DEV-1214

![image](https://user-images.githubusercontent.com/4517712/93088223-4e7a6380-f6a2-11ea-962c-7ca44cd72776.png)


<!--

# 🎉 Thanks for taking the time to contribute to Findify! 🎉

It is highly appreciated that you take the time to help improve Findify.
We appreciate it if you would take the time to document your Pull Request.

Before submitting a new PR please read the [CONTRIBUTING.md](./CONTRIBUTING.md).
