### PR TITLE
fix(@findify/bundle): terminate initializer if merchant is paused or …

### DIFF
--- a/packages/bundle/src/initialize.ts
+++ b/packages/bundle/src/initialize.ts
@@ -111,6 +111,7 @@ export default async (_config, sentry) => {
     resolveCallback(__root, 'findifyForceCallbacks');
     log(`findify ${__root.config.get('status')}`, 'color: #D9463F');
     showFallback(document);
+    return;
   }
 
   /**


### PR DESCRIPTION
## Summary
Terminate initializer if merchant status is `paused` or `disabled`