### PR TITLE
added ability to prevent autocompmlete rerendering on input change

### DIFF
--- a/packages/bundle/src/config.ts
+++ b/packages/bundle/src/config.ts
@@ -95,6 +95,7 @@ const config: Config = {
   features: {
     autocomplete: {
       instant: false,
+      disableRerenderingOnInputChange: false,
       handleFormSubmit: true,
       enableTrendingSearches: true,
       renderIn: 'body',

--- a/packages/bundle/src/features/autocomplete/handlers.ts
+++ b/packages/bundle/src/features/autocomplete/handlers.ts
@@ -123,7 +123,9 @@ export const registerHandlers = (
       return updateReferencedAgents(value, true);
     }
     agent.set('q', value);
-    rerender('initial');
+    if (!config.get('disableRerenderingOnInputChange')) {
+      rerender('initial');
+    }
   };
 
   const insideAutocomplete = (node: HTMLElement) => {

--- a/packages/config/src/Autocomplete.ts
+++ b/packages/config/src/Autocomplete.ts
@@ -107,6 +107,8 @@ export interface Autocomplete extends Omit<BaseFeature<'Autocomplete'>, 'product
   */
   enableTrendingSearches: boolean
 
+  disableRerenderingOnInputChange?: boolean,
+
   mobile: AutocompleteSizeType
   desktop: AutocompleteSizeType
 }


### PR DESCRIPTION
## Summary
- Added new optional autocomplete config `disableRerenderingOnInputChange` that prevents autocomplete rerender on input change

## References:
https://findify.atlassian.net/browse/DEV-3548