### PR TITLE
fix(@findify/react-components): fix LoadMore not showing when Combine…

### DIFF
--- a/packages/react-components/src/components/search/CombinedResults/index.tsx
+++ b/packages/react-components/src/components/search/CombinedResults/index.tsx
@@ -19,6 +19,7 @@
  import Pagination from 'components/Pagination';
  
  export default ({ theme = styles, card = ProductCard, itemConfig }) => {
+   console.log('InsideCoombined')
    const {
      container,
      onLoadNext,
@@ -72,7 +73,7 @@
            order: (item) => item.get('position'),
          })}
        </Grid>
-       <div className={theme.buttonContainer} display-if={displayNextButton}>
+       <div className={theme.buttonContainer}>
          <Button
            className={theme.nextButton}
            onClick={onLoadNext}


### PR DESCRIPTION

- LoadMore button should always show when combined option is configured

- relate to bug DEV-3643

<!--

# 🎉 Thanks for taking the time to contribute to Findify! 🎉

It is highly appreciated that you take the time to help improve Findify.
We appreciate it if you would take the time to document your Pull Request.

Before submitting a new PR please read the [CONTRIBUTING.md](./CONTRIBUTING.md).
