### PR TITLE
Feature/dev 3755 update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "npm-check-updates": "^11.1.4",
     "npm-run-all": "^4.1.5",
     "perfectionist": "^2.4.0",
-    "postcss": "^6.0.22",
+    "postcss": "^7.0.36",
     "postcss-discard-empty": "^2.1.0",
     "postcss-merge-rules": "^2.1.2",
     "prettier": "^2.2.1",

--- a/packages/bundle/webpack.config.ts
+++ b/packages/bundle/webpack.config.ts
@@ -44,8 +44,8 @@ const createGlobals = (isDevelopment, isLocal) =>
       [name]: isDevelopment
         ? 'false'
         : isLocal
-        ? (process.env[name] && JSON.stringify(process.env[name])) || name
-        : name,
+          ? (process.env[name] && JSON.stringify(process.env[name])) || name
+          : name,
     }),
     {}
   );
@@ -93,6 +93,7 @@ module.exports = (env: WebpackEnvArgs, { mode }) => {
     },
     stats: 'minimal',
     bail: true,
+    amd: false,
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.css'],
       alias: {
@@ -104,9 +105,6 @@ module.exports = (env: WebpackEnvArgs, { mode }) => {
     },
     module: {
       rules: [
-        {
-          parser: { amd: false },
-        },
         {
           test: /\.css$/,
           include: [path.resolve(componentsPath, 'src')],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "author": "bitaru <yourfriend@findify.io>",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^0.21.2",
     "chalk": "^2.4.2",
     "cheerio": "^1.0.0-rc.3",
     "jsdom": "^15.1.1",

--- a/packages/processors/package.json
+++ b/packages/processors/package.json
@@ -17,7 +17,7 @@
     "cssnano-browser": "^4.0.5",
     "flat": "^4.0.0",
     "lodash": "^4.17.20",
-    "postcss": "^6.0.22",
+    "postcss": "^7.0.36",
     "postcss-custom-properties": "^7.0.0",
     "webpack-cli": "^4.5.0"
   },

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -18,7 +18,7 @@
     "react-spring": "^8.0.27",
     "react-virtualized": "^9.22.3",
     "recompose": "^0.30.0",
-    "swiper": "^6.4.15"
+    "swiper": "^6.5.1"
   },
   "devDependencies": {
     "@findify/store-configuration": "^0.3.10",
@@ -42,7 +42,7 @@
     "json5": "^2.2.0",
     "npm-check-updates": "^11.1.4",
     "npm-run-all": "^4.1.5",
-    "postcss": "^6.0.22",
+    "postcss": "^7.0.36",
     "postcss-calc": "^6.0.1",
     "postcss-clearfix": "^2.0.1",
     "postcss-cli": "^5.0.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,9 +38,9 @@
     "docs": "typedoc --name 'Findify SDK' --hideGenerator --target es5 --theme default --out doc src"
   },
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^0.21.2",
     "debug": "^4.3.1",
-    "nanoid": "^3.1.20",
+    "nanoid": "^3.1.31",
     "qs": "^6.9.6"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,12 +3613,12 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+axios@^0.21.2:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
-    follow-redirects "^1.10.0"
+    follow-redirects "^1.14.0"
 
 b3b@0.0.1:
   version "0.0.1"
@@ -7531,10 +7531,15 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.146.0.tgz#e389013c4c2bee1ca09a59957223685f8bbefb02"
   integrity sha512-lMaDIdcEsdtKL0B+VFp8et/AjnB+cU1HJ6KDrp4Lw3Gsq0Ck0cmWRDgWfUQxxDvY99ntQyA/IdyFxFK4izKo4g==
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0:
+follow-redirects@^1.0.0:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
   integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+
+follow-redirects@^1.14.0:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -11573,6 +11578,11 @@ nanoid@^3.1.20:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
   integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
 
+nanoid@^3.1.31:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -12723,6 +12733,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -13739,7 +13754,7 @@ postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.18, postcss@^6.0.2, postcss@^6.0.22, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.8, postcss@^6.0.9:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.18, postcss@^6.0.2, postcss@^6.0.23, postcss@^6.0.6, postcss@^6.0.8, postcss@^6.0.9:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
@@ -13756,6 +13771,14 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^7.0.36:
+  version "7.0.39"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+  dependencies:
+    picocolors "^0.2.1"
+    source-map "^0.6.1"
 
 postcss@^8.2.8:
   version "8.2.8"
@@ -16133,10 +16156,10 @@ svgo@^1.0.0, svgo@^1.3.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swiper@^6.4.15:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.5.0.tgz#4ca2243b44fccef47ee28199377666607d8c5141"
-  integrity sha512-cSx1SpfgrHlgwku++3Ce3cjPBpXgB7P+bGik5S3+F+j6ID0NUeV6qtmedFdr3C8jXR/W+TJPVNIT9fH/cwVAiA==
+swiper@^6.5.1:
+  version "6.8.4"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.8.4.tgz#938fed4144f4d7952fbf9c44e5832d133a4de794"
+  integrity sha512-O+buF9Q+sMA0H7luMS8R59hCaJKlpo8PXhQ6ZYu6Rn2v9OsFd4d1jmrv14QvxtQpKAvL/ZiovEeANI/uDGet7g==
   dependencies:
     dom7 "^3.0.0"
     ssr-window "^3.0.0"


### PR DESCRIPTION
This PR resolves our critical dependencies and some others with less severity.
Only direct dependencies were updated.

Webpack amd option is moved out from rules as it shouldn't be a rule but an extra option. More details regarding it are here:
https://webpack.js.org/configuration/other-options/

FYI, amd option inform webpack how to manage different versions of packages that relies on amd, with this to false it doesn't check them and all can be used. AMD package such as JQuery.