### PR TITLE
fix(@findify/sdk): expose request types as JS object in SDK

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,7 @@ import { Config, Client } from './client';
 import * as R from './request';
 import { validateConfig } from './validation';
 import * as settings from './settings';
+export { Type as RequestType } from './request/Type';
 
 const knownEnvs = ['development', 'staging', 'production'];
 


### PR DESCRIPTION
## Summary
To fix this issue: https://github.com/findify/findify-js/issues/809 I've added `RequestType` to the exposed objects of the SDK

I don't want to replace `RequestType` enum with string type as it will require quite a lot of refactoring in MJS projects (a lot of projects use `RequestType` enum)