### PR TITLE
Re-added import of lodash/escapeRegExp for retrocompatibility

### DIFF
--- a/packages/react-components/src/components/CheckboxFacet/index.tsx
+++ b/packages/react-components/src/components/CheckboxFacet/index.tsx
@@ -13,6 +13,7 @@ import { ThemedSFCProps, MJSConfiguration, IFacet } from 'types';
 import content from 'components/CheckboxFacet/content';
 import useTranslations from 'helpers/useTranslations';
 import VirtualizedList from 'components/common/VirtualizedList';
+import escapeRegExp from 'lodash/escapeRegExp';
 import styles from 'components/CheckboxFacet/styles.css';;
 
 /** Props that CheckboxFacet accepts */


### PR DESCRIPTION
Solving retro-compatibility issue introduced on 7.1.54
- import of lodash/escapeRegExp
