### PR TITLE
Redirection to be read from merchant config FE

### DIFF
--- a/packages/bundle/src/config.ts
+++ b/packages/bundle/src/config.ts
@@ -561,6 +561,9 @@ const config: Config = {
     },
     recommendations: {},
   },
+  redirections: {
+    test: 'https://liverpoolstyle.com/collections/liverpool-x-caitlin-covington'
+  },
   merchantName: 'findify-staging.myshopify.com',
   mjs_version: '7.1.0',
 };

--- a/packages/bundle/src/core/location.ts
+++ b/packages/bundle/src/core/location.ts
@@ -1,5 +1,6 @@
 import { createBrowserHistory } from 'history';
 import { parse, stringify } from 'qs';
+import { isImmutable } from 'immutable';
 
 let history = createBrowserHistory();
 let historyChanged = false;
@@ -128,8 +129,9 @@ export const setQuery = (query) => {
 };
 
 export const redirectToPage = async (redirect, meta) => {
+  const redirection = isImmutable(redirect) ? redirect.toJS() : redirect;
   await __root.analytics.sendEvent('redirect', {
-    ...redirect.toJS(),
+    ...redirection,
     rid: meta.get('rid'),
     suggestion: meta.get('q'),
   });
@@ -138,13 +140,13 @@ export const redirectToPage = async (redirect, meta) => {
   if (isHistoryChanged()) {
     const origin = document.location.origin + getBasepath();
     return getHistory().push(
-      redirect.get('url')
+      redirection.url
         .replace(origin, ''),
       { type: 'FindifyUpdate' }
     );
   }
   // Other websites - Redirection replaces the whole location
-  document.location.href = getBasepath() + redirect.get('url');
+  document.location.href = getBasepath() + redirection.url;
 };
 
 export const updateHash = (hash: string) => {

--- a/packages/bundle/src/core/location.ts
+++ b/packages/bundle/src/core/location.ts
@@ -128,6 +128,12 @@ export const setQuery = (query) => {
   return getHistory().push({ search, state: { type: 'FindifyUpdate' } });
 };
 
+/**
+ * 
+ * @param redirect redirection are configured in MD and forwarded to MerchantConfig.
+ * @param meta request body information.
+ * @returns will redirect to such URL.
+ */
 export const redirectToPage = async (redirect, meta) => {
   const redirection = isImmutable(redirect) ? redirect.toJS() : redirect;
   await __root.analytics.sendEvent('redirect', {

--- a/packages/bundle/src/features/autocomplete/handlers.ts
+++ b/packages/bundle/src/features/autocomplete/handlers.ts
@@ -168,19 +168,12 @@ export const registerHandlers = (
     __root.emit(Events.autocompleteFocusLost, widget.key);
 
     const value = _value || agent.state.get('q') || '';
-    const [query, redirect] = isImmutable(value)
-      ? [value.get('value'), value.get('redirect')]
-      : [value, agent.response.get('redirect')];
+    const query = isImmutable(value) ? value.get('value') : value;
 
     // Redirection from query submitted checking FE config
     const feConfigRedirectionMatch = config.getIn(['redirections', query?.toLowerCase()]);
     if (!!feConfigRedirectionMatch) {
       return redirectToPage({ name: feConfigRedirectionMatch, url: feConfigRedirectionMatch }, agent.response.get('meta'));
-    }
-
-    // Redirection from autocomplete responde
-    if (redirect) {
-      return redirectToPage(redirect, agent.response.get('meta'));
     }
 
     if (!isSearch()) return redirectToSearch(query);

--- a/packages/bundle/src/features/autocomplete/handlers.ts
+++ b/packages/bundle/src/features/autocomplete/handlers.ts
@@ -172,6 +172,13 @@ export const registerHandlers = (
       ? [value.get('value'), value.get('redirect')]
       : [value, agent.response.get('redirect')];
 
+    // Redirection from query submitted checking FE config
+    const feConfigRedirectionMatch = config.getIn(['redirections', query?.toLowerCase()]);
+    if (!!feConfigRedirectionMatch) {
+      return redirectToPage({ name: feConfigRedirectionMatch, url: feConfigRedirectionMatch }, agent.response.get('meta'));
+    }
+
+    // Redirection from autocomplete responde
     if (redirect) {
       return redirectToPage(redirect, agent.response.get('meta'));
     }

--- a/packages/bundle/src/features/search/index.ts
+++ b/packages/bundle/src/features/search/index.ts
@@ -92,9 +92,6 @@ export default (render, widget: Widget<Immutable.SearchConfig>) => {
     render('initial');
   });
 
-  // Redirection from event
-  agent.on('change:redirect', redirectToPage);
-
   /** Listen to location back/fwd */
   const stopListenLocation = listenHistory((history, action) => {
     if (history.action !== 'POP' && action !== 'POP') return;

--- a/packages/bundle/src/features/search/index.ts
+++ b/packages/bundle/src/features/search/index.ts
@@ -79,11 +79,20 @@ export default (render, widget: Widget<Immutable.SearchConfig>) => {
 
   /** Listen to changes */
   agent.on('change:query', (q, meta) => {
-    setQuery(q.toJS());
+    const query = q.toJS();
+    setQuery(query);
+
+    // Redirection from query loaded checking FE config
+    const feConfigRedirectionMatch = config.getIn(['redirections', query?.q?.toLowerCase()]);
+    if (!!feConfigRedirectionMatch) {
+      return redirectToPage({ name: feConfigRedirectionMatch, url: feConfigRedirectionMatch }, meta);
+    }
+
     if (!meta.get('total')) return renderZeroResults();
     render('initial');
   });
 
+  // Redirection from event
   agent.on('change:redirect', redirectToPage);
 
   /** Listen to location back/fwd */

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -36,7 +36,7 @@ export type Config = {
    * Should observe dom change to dynamically attach/detach widgets
    * @warn this change may slow down website
    */
-	observeDomChanges: boolean
+  observeDomChanges: boolean
 
   /** URL management configuration */
   location: {
@@ -61,7 +61,7 @@ export type Config = {
 
   /** Currency display setup */
   currency: {
-    code: string, 
+    code: string,
     symbol: string,
     thousand: string,
     decimal: string,
@@ -103,4 +103,14 @@ export type Config = {
   components: {
     [key: string]: () => void
   }
+
+  /** Map redirection url set within MD  */
+  redirections?: {
+    [key: string]: string
+  }
+
+  platform_settings?: {
+    multi_market?: boolean
+  }
+
 }

--- a/packages/config/src/Immutable.ts
+++ b/packages/config/src/Immutable.ts
@@ -58,6 +58,7 @@ type FEConfig = {
   widgetType: enums.Feature,
   cssSelector?: string
   slot?: string
+  redirections?: { [key: string]: string }[];
 }
 
 export type BaseConfig = Factory<Config & FEConfig>


### PR DESCRIPTION
Redirection to be read from merchant Config FE.
This is additional on top of the already read event.

Updated types of @findify/store-configuration to include -> platform_settings & redirections