### PR TITLE
Fix API URL for staging

### DIFF
--- a/packages/analytics/src/settings.ts
+++ b/packages/analytics/src/settings.ts
@@ -1,6 +1,6 @@
 export const env = {
   staging:{
-    searchApiUrl: 'https://search-staging.findify.io/v4',
+    searchApiUrl: 'https://api.staging.findify.io/v4',
     bigcommerceTrackingUrl: 'https://order.findify.io/bigcommerce-staging',
   },
 

--- a/packages/sdk/src/settings.ts
+++ b/packages/sdk/src/settings.ts
@@ -5,7 +5,7 @@ const common = {
 
 export const staging = {
   ...common,
-  url: 'https://search-staging.findify.io/v4',
+  url: 'https://api.staging.findify.io/v4',
   // usually you don't want to
   // retry failed requests on staging
   retryCount: 1,


### PR DESCRIPTION
`search-staging.findify.io` doesn't work - replaced it with the current URL to ensure staging dashboard works correctly.
There are a lot of very old fixtures in https://github.com/findify/findify-js/tree/develop/packages/sdk/src/client/__tests__/__~fixtures__ which are probably trash, but I don't know enough about this repo for me to touch that 😅 