### PR TITLE
Blur on Escape key pressed for autocomplete blinking issue

### DIFF
--- a/packages/bundle/src/features/autocomplete/handlers.ts
+++ b/packages/bundle/src/features/autocomplete/handlers.ts
@@ -154,6 +154,8 @@ export const registerHandlers = (
 
   const handleEscape = ({ key }) => {
     if (key === 'Escape') {
+      // @ts-ignore
+      document.activeElement?.blur();
       __root.emit(Events.autocompleteFocusLost, widget.key)
     }
   }


### PR DESCRIPTION
Bundle - Autocomplete - on Esc press, blur() to lose focus and so, safely close autocomplete.